### PR TITLE
project management: Cask, tests and CI

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -1,0 +1,8 @@
+[Default]
+enabled = True
+
+[commit]
+bears = GitCommitBear
+
+[python]
+bears = PEP8Bear

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+sudo: no
+python:
+  - 3.4
+  - 3.5
+  - 3.6
+env:
+  - EVM_EMACS=emacs-24.4-travis
+  - EVM_EMACS=emacs-24.5-travis
+  - EVM_EMACS=emacs-25.1-travis
+  - EVM_EMACS=emacs-25.2-travis
+before_install:
+  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > travis.sh && source ./travis.sh
+  - evm install $EVM_EMACS --use --skip
+  - cask
+install:
+  - pip install -r requirements.txt
+script:
+  - PYTHONPATH="`pwd`" cask exec ert-runner

--- a/Cask
+++ b/Cask
@@ -1,0 +1,10 @@
+(source gnu)
+(source melpa)
+
+(package "flycheck-coala" "0.1" "Flycheck plugin for coala.io code analyzer")
+
+(development
+ (depends-on "dash")
+ (depends-on "flycheck")
+ (depends-on "f")
+ (depends-on "ert-runner"))

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Flycheck coala Checker
 ======================
+[![Build Status](https://travis-ci.org/coala/coala-emacs.svg?branch=master)](https://travis-ci.org/coala/coala-emacs)
 
 Integrate [coala](https://coala.io) with
 [flycheck](http://www.flycheck.org).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+coala
+coala-bears
+pyflakes~=1.4.0

--- a/test/coala-test.el
+++ b/test/coala-test.el
@@ -1,0 +1,18 @@
+;;; coala-emacs --- tests
+;;; Commentary:
+(require 'flycheck)
+(require 'flycheck-ert)
+
+;;; Code:
+
+;;; Directories
+
+(flycheck-ert-def-checker-test coala python coala-python
+  (unwind-protect
+      (flycheck-ert-should-syntax-check
+       "test/resources/language/pep8.py" 'python-mode
+       '(1 nil warning "The code does not comply to PEP8."
+           :checker coala))))
+
+(provide 'coala-test)
+;;; coala-test.el ends here

--- a/test/resources/language/pep8.py
+++ b/test/resources/language/pep8.py
@@ -1,0 +1,1 @@
+a = 1 + 1 # <- not PEP8 compliant

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,0 +1,7 @@
+;; -*- lexical-binding: t -*-
+
+(require 'f)
+(let ((coala-emacs-dir (f-parent (f-dirname (f-this-file)))))
+  (add-to-list 'load-path coala-emacs-dir)
+  (add-to-list 'process-environment (format "PYTHONPATH=%s" coala-emacs-dir)))
+(require 'flycheck-coala)


### PR DESCRIPTION
Use the ``cask`` library for project management.  Use ``ert`` for tests.
Adds an exemplary test for the PEP8Bear.  CI is also part of project
management.

Closes https://github.com/coala/coala-emacs/issues/11
