### PR TITLE
coala command: use --limit-files

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -1,8 +1,7 @@
-[Default]
-enabled = True
-
 [commit]
 bears = GitCommitBear
 
 [python]
 bears = PEP8Bear
+files = **.py
+ignore = test/resources/language/*.py

--- a/flycheck-coala.el
+++ b/flycheck-coala.el
@@ -34,7 +34,7 @@
 (flycheck-define-checker coala
   "A checker using coala.
 See URL `https://coala.io'."
-  :command ("coala" "--format" "{line}:{column}:{severity_str}:{message}" "--find-config" "--files" source)
+  :command ("coala" "--format" "{line}:{column}:{severity_str}:{message}" "--find-config" "--limit-files" source-original)
   :error-patterns  ((error (or "None" line) ":" (or "None" column) ":MAJOR:" (message))
                     (warning (or "None" line) ":" (or "None" column) ":NORMAL:" (message))
                     (info (or "None" line) ":" (or "None" column) ":INFO:" (message)))

--- a/test/resources/language/.coafile
+++ b/test/resources/language/.coafile
@@ -1,0 +1,3 @@
+[python]
+bears = PEP8Bear
+files = *.py


### PR DESCRIPTION
Uses `--limit-files` instead of `--files`.  Also, additional line-start
and line-end regexp patterns.